### PR TITLE
net.Dial use IP_BIND_ADDRESS_NO_PORT sockopts

### DIFF
--- a/src/net/sock_posix.go
+++ b/src/net/sock_posix.go
@@ -127,6 +127,9 @@ func (fd *netFD) dial(ctx context.Context, laddr, raddr sockaddr) error {
 		if lsa, err = laddr.sockaddr(fd.family); err != nil {
 			return err
 		} else if lsa != nil {
+			if taddr, ok := laddr.(*TCPAddr); ok && taddr.IP != nil && taddr.Port == 0 {
+				trySetBindNoPortSockopts(fd.sysfd)
+			}
 			if err := syscall.Bind(fd.sysfd, lsa); err != nil {
 				return os.NewSyscallError("bind", err)
 			}

--- a/src/net/sockopt_bsd.go
+++ b/src/net/sockopt_bsd.go
@@ -52,3 +52,5 @@ func setDefaultMulticastSockopts(s int) error {
 	// quick draw possible.
 	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_REUSEPORT, 1))
 }
+
+func trySetBindNoPortSockopts(s int) {}

--- a/src/net/sockopt_linux.go
+++ b/src/net/sockopt_linux.go
@@ -30,3 +30,8 @@ func setDefaultMulticastSockopts(s int) error {
 	// concurrently across multiple listeners.
 	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1))
 }
+
+func trySetBindNoPortSockopts(s int) {
+	const IP_BIND_ADDRESS_NO_PORT = 24
+	syscall.SetsockoptInt(s, syscall.IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT, 1)
+}

--- a/src/net/sockopt_solaris.go
+++ b/src/net/sockopt_solaris.go
@@ -30,3 +30,5 @@ func setDefaultMulticastSockopts(s int) error {
 	// concurrently across multiple listeners.
 	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1))
 }
+
+func trySetBindNoPortSockopts(s int) {}

--- a/src/net/sockopt_stub.go
+++ b/src/net/sockopt_stub.go
@@ -20,6 +20,8 @@ func setDefaultMulticastSockopts(s int) error {
 	return nil
 }
 
+func trySetBindNoPortSockopts(s int) {}
+
 func setReadBuffer(fd *netFD, bytes int) error {
 	return syscall.ENOPROTOOPT
 }

--- a/src/net/sockopt_windows.go
+++ b/src/net/sockopt_windows.go
@@ -36,3 +36,5 @@ func setDefaultMulticastSockopts(s syscall.Handle) error {
 	// concurrently across multiple listeners.
 	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1))
 }
+
+func trySetBindNoPortSockopts(s int) {}


### PR DESCRIPTION
https://golang.org/cl/72810
发布后，就没必要使用这个patch了